### PR TITLE
Remove rabbit exchange routing key as it is useless

### DIFF
--- a/config/routing.yaml
+++ b/config/routing.yaml
@@ -1,26 +1,9 @@
 # Message Routing Configuration
 # This file defines the exchange names and routing keys for outbox events
 
-create_server:
-  - "created_server" # Exchange name (fanout)
-  - "server.created" # Routing key
-
-delete_server:
-  - "beep.community" # Exchange name
-  - "server.deleted" # Routing key
-
-create_channel:
-  - "beep.community" # Exchange name
-  - "channel.created" # Routing key
-
-delete_channel:
-  - "beep.community" # Exchange name
-  - "channel.deleted" # Routing key
-
-update_channel:
-  - "beep.community" # Exchange name
-  - "channel.updated" # Routing key
-
-create_role:
-  - "role.create"
-  - ""
+create_server: "create.server"
+delete_server: "delete.server"
+create_channel: "create.channel"
+delete_channel: "delete.channel"
+update_channel: "update.channel"
+create_role: "role.create"

--- a/core/migrations/20251223130000_create_member_roles_table.down.sql
+++ b/core/migrations/20251223130000_create_member_roles_table.down.sql
@@ -1,0 +1,10 @@
+-- Down migration: drop member_roles table, function, and trigger
+
+-- Drop trigger
+DROP TRIGGER IF EXISTS member_role_same_server_check ON member_roles;
+
+-- Drop function
+DROP FUNCTION IF EXISTS check_member_role_same_server();
+
+-- Drop table
+DROP TABLE IF EXISTS member_roles;

--- a/core/migrations/20260115120000_remove_routing_key_from_outbox.down.sql
+++ b/core/migrations/20260115120000_remove_routing_key_from_outbox.down.sql
@@ -1,0 +1,3 @@
+-- Down migration: add routing_key column back to outbox_messages table
+
+ALTER TABLE outbox_messages ADD COLUMN routing_key VARCHAR(255) NOT NULL DEFAULT '';

--- a/core/migrations/20260115120000_remove_routing_key_from_outbox.up.sql
+++ b/core/migrations/20260115120000_remove_routing_key_from_outbox.up.sql
@@ -1,0 +1,3 @@
+-- Up migration: remove routing_key column from outbox_messages table
+
+ALTER TABLE outbox_messages DROP COLUMN IF EXISTS routing_key;

--- a/core/src/domain/outbox/entities.rs
+++ b/core/src/domain/outbox/entities.rs
@@ -12,7 +12,6 @@ use crate::domain::outbox::error::OutboxError;
 pub struct OutboxMessage {
     pub id: Uuid,
     pub exchange_name: String,
-    pub routing_key: String,
     pub payload: serde_json::Value,
     pub status: OutboxStatus,
     pub failed_at: Option<DateTime<Utc>>,

--- a/core/src/infrastructure/member_role/repositories/postgres.rs
+++ b/core/src/infrastructure/member_role/repositories/postgres.rs
@@ -166,8 +166,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_assign_member_to_role(pool: PgPool) -> Result<(), CoreError> {
-        let assign_role_routing =
-            MessageRoutingInfo::new("test".to_string(), "test_routing".to_string());
+        let assign_role_routing = MessageRoutingInfo::new("test");
         let repository = PostgresMemberRoleRepository::new(pool.clone(), assign_role_routing);
         let server_id = create_test_server(&pool.clone(), "test_server").await;
         let role_id = create_test_role(&pool.clone(), server_id).await;
@@ -185,8 +184,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_unassign_member_from_role(pool: PgPool) -> Result<(), CoreError> {
-        let assign_role_routing =
-            MessageRoutingInfo::new("test".to_string(), "test_routing".to_string());
+        let assign_role_routing = MessageRoutingInfo::new("test");
         let repository = PostgresMemberRoleRepository::new(pool.clone(), assign_role_routing);
         let server_id = create_test_server(&pool.clone(), "test_server").await;
         let role_id = create_test_role(&pool.clone(), server_id).await;

--- a/core/src/infrastructure/role/repositories/postgres.rs
+++ b/core/src/infrastructure/role/repositories/postgres.rs
@@ -238,12 +238,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_create_role_writes_row(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server_id = create_test_server(&pool, "Test Server").await;
@@ -270,12 +267,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_create_role_writes_outbox(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test.exchange".to_string(), "test.role.created".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test.exchange");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo = PostgresRoleRepository::new(
             pool.clone(),
             create_router.clone(),
@@ -295,23 +289,20 @@ mod tests {
         // Assert: an outbox message was written with expected routing and payload
         let row = sqlx::query(
             r#"
-            SELECT exchange_name, routing_key, payload
+            SELECT exchange_name, payload
             FROM outbox_messages
-            WHERE exchange_name = $1 AND routing_key = $2
+            WHERE exchange_name = $1
             ORDER BY created_at DESC
             LIMIT 1
             "#,
         )
         .bind(create_router.exchange_name())
-        .bind(create_router.routing_key())
         .fetch_one(&pool)
         .await
         .unwrap();
 
         let exchange_name: String = row.try_get("exchange_name").unwrap();
-        let routing_key: String = row.try_get("routing_key").unwrap();
         assert_eq!(exchange_name, create_router.exchange_name());
-        assert_eq!(routing_key, create_router.routing_key());
 
         // Validate the payload JSON contains the role data
         let payload: serde_json::Value = row.try_get("payload").unwrap();
@@ -328,12 +319,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_find_by_id_returns_error_for_nonexistent(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo = PostgresRoleRepository::new(pool, create_router, update_router, delete_router);
         let nonexistent_id = RoleId(Uuid::new_v4());
 
@@ -348,12 +336,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_list_by_server_with_pagination(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server_id = create_test_server(&pool, "Test Server").await;
@@ -383,12 +368,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_list_by_server_filters_by_server_id(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server1_id = create_test_server(&pool, "Server 1").await;
@@ -430,12 +412,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_update_role_updates_fields(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server_id = create_test_server(&pool, "Test Server").await;
@@ -468,12 +447,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_update_role_writes_outbox(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test.exchange".to_string(), "test.role.updated".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test.exchange");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo = PostgresRoleRepository::new(
             pool.clone(),
             create_router,
@@ -500,23 +476,20 @@ mod tests {
         // Assert: an outbox message was written with expected routing and payload
         let row = sqlx::query(
             r#"
-            SELECT exchange_name, routing_key, payload
+            SELECT exchange_name, payload
             FROM outbox_messages
-            WHERE exchange_name = $1 AND routing_key = $2
+            WHERE exchange_name = $1 
             ORDER BY created_at DESC
             LIMIT 1
             "#,
         )
         .bind(update_router.exchange_name())
-        .bind(update_router.routing_key())
         .fetch_one(&pool)
         .await
         .unwrap();
 
         let exchange_name: String = row.try_get("exchange_name").unwrap();
-        let routing_key: String = row.try_get("routing_key").unwrap();
         assert_eq!(exchange_name, update_router.exchange_name());
-        assert_eq!(routing_key, update_router.routing_key());
 
         // Validate the payload JSON contains the update data
         let payload: serde_json::Value = row.try_get("payload").unwrap();
@@ -536,12 +509,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_update_nonexistent_role_returns_error(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo = PostgresRoleRepository::new(pool, create_router, update_router, delete_router);
         let nonexistent_id = RoleId(Uuid::new_v4());
 
@@ -562,12 +532,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_delete_role_removes_row(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server_id = create_test_server(&pool, "Test Server").await;
@@ -593,12 +560,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_delete_role_writes_outbox(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test.exchange".to_string(), "test.role.deleted".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test.exchange");
         let repo = PostgresRoleRepository::new(
             pool.clone(),
             create_router,
@@ -621,23 +585,20 @@ mod tests {
         // Assert: an outbox message was written with expected routing and payload
         let row = sqlx::query(
             r#"
-            SELECT exchange_name, routing_key, payload
+            SELECT exchange_name, payload
             FROM outbox_messages
-            WHERE exchange_name = $1 AND routing_key = $2
+            WHERE exchange_name = $1 
             ORDER BY created_at DESC
             LIMIT 1
             "#,
         )
         .bind(delete_router.exchange_name())
-        .bind(delete_router.routing_key())
         .fetch_one(&pool)
         .await
         .unwrap();
 
         let exchange_name: String = row.try_get("exchange_name").unwrap();
-        let routing_key: String = row.try_get("routing_key").unwrap();
         assert_eq!(exchange_name, delete_router.exchange_name());
-        assert_eq!(routing_key, delete_router.routing_key());
 
         // Validate the payload JSON contains the role id
         let payload: serde_json::Value = row.try_get("payload").unwrap();
@@ -647,12 +608,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_delete_nonexistent_returns_error(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo = PostgresRoleRepository::new(pool, create_router, update_router, delete_router);
         let nonexistent_id = RoleId(Uuid::new_v4());
 
@@ -667,12 +625,9 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_cascade_delete_when_server_deleted(pool: PgPool) {
-        let create_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.create".to_string());
-        let update_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.update".to_string());
-        let delete_router =
-            MessageRoutingInfo::new("test".to_string(), "test.role.delete".to_string());
+        let create_router = MessageRoutingInfo::new("test");
+        let update_router = MessageRoutingInfo::new("test");
+        let delete_router = MessageRoutingInfo::new("test");
         let repo =
             PostgresRoleRepository::new(pool.clone(), create_router, update_router, delete_router);
         let server_id = create_test_server(&pool, "Test Server").await;


### PR DESCRIPTION
I removed the rabbit routing key. It is a relic from a misunderstood concept : exchange.
I am merging this anyway