### PR TITLE
Create member routing

### DIFF
--- a/api/src/http/server_members/routes.rs
+++ b/api/src/http/server_members/routes.rs
@@ -1,15 +1,16 @@
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::{
-    http::server::AppState,
-    http::server_members::handlers::{
-        __path_delete_member, __path_list_members, __path_update_member, delete_member,
-        list_members, update_member,
+use crate::http::{
+    server::AppState,
+    server_members::handlers::{
+        __path_create_member, __path_delete_member, __path_list_members, __path_update_member,
+        create_member, delete_member, list_members, update_member,
     },
 };
 
 pub fn server_member_routes() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
+        .routes(routes!(create_member))
         .routes(routes!(list_members))
         .routes(routes!(update_member))
         .routes(routes!(delete_member))

--- a/openapi.json
+++ b/openapi.json
@@ -1271,6 +1271,100 @@
             "bearer_auth": []
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "server_members"
+        ],
+        "operationId": "create_member",
+        "parameters": [
+          {
+            "name": "server_id",
+            "in": "path",
+            "description": "Server ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Member created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerMember"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid nickname",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Server not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Member already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
       }
     },
     "/servers/{server_id}/members/{user_id}": {


### PR DESCRIPTION
The logic and http handler were already there but the route was not exposed. 
The goal of this pr is to add the route to create member. It will allow member to join any public member with the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for creating server members with comprehensive error handling and bearer token authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->