### PR TITLE
feat(logging): add HTTP request instrumentation and correlation ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "test-context",
  "thiserror",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -4140,6 +4141,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,7 +11,8 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-tower-http = { version = "0.6.6", features = ["cors"] }
+tower-http = { version = "0.6.6", features = ["cors", "trace", "request-id"] }
+tower = { version = "0.5", features = ["util"] }
 communities-core = { path = "../core", package = "communities_core" }
 outbox_dispatch = { path = "../outbox_dispatch", package = "outbox_dispatch" }
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio", "uuid"] }

--- a/api/src/app.rs
+++ b/api/src/app.rs
@@ -1,10 +1,17 @@
 use axum::{
     http::{
-        HeaderValue, Method,
+        HeaderValue, Method, Request, Response,
         header::{AUTHORIZATION, CONTENT_TYPE},
     },
     middleware::from_extractor_with_state,
 };
+use std::time::Duration;
+use tower::ServiceBuilder;
+use tower_http::{
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+use tracing::Span;
 use communities_core::{
     application::{BeepServicesConfig, CommunitiesRepositories},
     create_repositories,
@@ -137,7 +144,34 @@ impl App {
         let dispatch = Dispatcher::new(outbox_stream, config.routing.clone(), rabbit_client);
         let app_router = app_router
             .with_state(state.clone())
-            .merge(Scalar::with_url("/scalar", api));
+            .merge(Scalar::with_url("/scalar", api))
+            .layer(
+                ServiceBuilder::new()
+                    .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+                    .layer(PropagateRequestIdLayer::x_request_id())
+                    .layer(
+                        TraceLayer::new_for_http()
+                            .make_span_with(|req: &Request<_>| {
+                                let request_id = req
+                                    .headers()
+                                    .get("x-request-id")
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("unknown");
+                                tracing::info_span!(
+                                    "http_request",
+                                    request_id = %request_id,
+                                    method     = %req.method(),
+                                    uri        = %req.uri(),
+                                )
+                            })
+                            .on_response(|res: &Response<_>, latency: Duration, _span: &Span| {
+                                tracing::info!(status = res.status().as_u16(), latency = ?latency, "response sent");
+                            })
+                            .on_failure(|error, latency: Duration, _span: &Span| {
+                                tracing::error!(error = %error, latency = ?latency, "request failed");
+                            }),
+                    ),
+            );
         // Write OpenAPI spec to file in development environment
         if matches!(config.environment, crate::config::Environment::Development) {
             std::fs::write("openapi.json", &openapi_json).map_err(|e| ApiError::StartupError {

--- a/api/src/http/channels/handlers.rs
+++ b/api/src/http/channels/handlers.rs
@@ -33,6 +33,7 @@ use uuid::Uuid;
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_server_channel(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -64,6 +65,7 @@ pub async fn create_server_channel(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state, _user_identity))]
 pub async fn create_private_channel(
     State(state): State<AppState>,
     Extension(_user_identity): Extension<UserIdentity>,
@@ -88,6 +90,7 @@ pub async fn create_private_channel(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn list_channels(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -116,6 +119,7 @@ pub async fn list_channels(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_channel(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
@@ -148,6 +152,7 @@ pub async fn get_channel(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn update_channel(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
@@ -183,6 +188,7 @@ pub async fn update_channel(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_channel(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,

--- a/api/src/http/friend/handlers.rs
+++ b/api/src/http/friend/handlers.rs
@@ -34,6 +34,7 @@ use crate::http::server::{
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_friends(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -65,6 +66,7 @@ pub async fn get_friends(
         (status = 404, description = "Friend not found"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_friend(
     Path(friend_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -96,6 +98,7 @@ pub async fn delete_friend(
         (status = 401, description = "Unauthorized"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_friend_requests(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -129,6 +132,7 @@ pub async fn get_friend_requests(
         (status = 401, description = "Unauthorized"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_friend_invitations(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -162,6 +166,7 @@ pub async fn get_friend_invitations(
         (status = 409, description = "Friend request already exists"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_friend_request(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -188,6 +193,7 @@ pub async fn create_friend_request(
         (status = 404, description = "Friend request not found"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn accept_friend_request(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -213,6 +219,7 @@ pub async fn accept_friend_request(
         (status = 404, description = "Friend request not found"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn decline_friend_request(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -239,6 +246,7 @@ pub async fn decline_friend_request(
         (status = 404, description = "Friend request not found"),
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_friend_request(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,

--- a/api/src/http/role/handlers.rs
+++ b/api/src/http/role/handlers.rs
@@ -40,6 +40,7 @@ use crate::{
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_role(
     State(state): State<AppState>,
     Path(server_id): Path<Uuid>,
@@ -78,6 +79,7 @@ pub async fn create_role(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_role(
     Path(role_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -110,6 +112,7 @@ pub async fn get_role(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn list_roles_by_server(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -147,6 +150,7 @@ pub async fn list_roles_by_server(
          (status = 500, description = "Internal server error")
      )
  )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_user_roles_in_server(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -177,6 +181,7 @@ pub async fn get_user_roles_in_server(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state, request), fields(user_id = %user_identity.user_id))]
 pub async fn update_role(
     Path(role_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -215,6 +220,7 @@ pub async fn update_role(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_role(
     Path(role_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -248,6 +254,7 @@ pub async fn delete_role(
          (status = 500, description = "Internal server error")
      )
  )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn assign_role(
     Path((role_id, member_id)): Path<(Uuid, Uuid)>,
     State(state): State<AppState>,
@@ -281,6 +288,7 @@ pub async fn assign_role(
          (status = 500, description = "Internal server error")
      )
  )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn unassign_role(
     Path((role_id, member_id)): Path<(Uuid, Uuid)>,
     State(state): State<AppState>,
@@ -313,6 +321,7 @@ pub async fn unassign_role(
          (status = 500, description = "Internal server error")
      )
  )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn list_members_by_role(
     Path(role_id): Path<Uuid>,
     State(state): State<AppState>,

--- a/api/src/http/server_invitations/handlers.rs
+++ b/api/src/http/server_invitations/handlers.rs
@@ -34,6 +34,7 @@ use crate::http::server::{ApiError, AppState, Response, middleware::auth::entiti
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_invitation(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -64,6 +65,7 @@ pub async fn create_invitation(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state, _user_identity))]
 pub async fn get_invitation(
     Path(invitation_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -89,6 +91,7 @@ pub async fn get_invitation(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn accept_invitation(
     Path(invitation_id): Path<Uuid>,
     State(state): State<AppState>,

--- a/api/src/http/server_members/handlers.rs
+++ b/api/src/http/server_members/handlers.rs
@@ -51,6 +51,7 @@ pub struct UpdateMemberRequest {
     ),
     security(("bearer_auth" = []))
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_member(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -91,6 +92,7 @@ pub async fn create_member(
     ),
     security(("bearer_auth" = []))
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn list_members(
     Path(server_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -132,6 +134,7 @@ pub async fn list_members(
     ),
     security(("bearer_auth" = []))
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn update_member(
     Path((server_id, user_id)): Path<(Uuid, Uuid)>,
     State(state): State<AppState>,
@@ -173,6 +176,7 @@ pub async fn update_member(
     ),
     security(("bearer_auth" = []))
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_member(
     Path((server_id, user_id)): Path<(Uuid, Uuid)>,
     State(state): State<AppState>,

--- a/api/src/http/servers/handlers.rs
+++ b/api/src/http/servers/handlers.rs
@@ -31,6 +31,7 @@ use crate::http::server::{
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn create_server(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -56,6 +57,7 @@ pub async fn create_server(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn get_server(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
@@ -82,6 +84,7 @@ pub async fn get_server(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %_user_identity.user_id))]
 pub async fn list_servers(
     State(state): State<AppState>,
     Extension(_user_identity): Extension<UserIdentity>,
@@ -111,6 +114,7 @@ pub async fn list_servers(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn list_user_servers(
     State(state): State<AppState>,
     Extension(user_identity): Extension<UserIdentity>,
@@ -147,6 +151,7 @@ pub async fn list_user_servers(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn update_server(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
@@ -180,6 +185,7 @@ pub async fn update_server(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %user_identity.user_id))]
 pub async fn delete_server(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
@@ -211,6 +217,7 @@ pub async fn delete_server(
         (status = 500, description = "Internal server error")
     )
 )]
+#[tracing::instrument(skip(state), fields(user_id = %_user_identity.user_id))]
 pub async fn search_or_discover_servers(
     State(state): State<AppState>,
     Extension(_user_identity): Extension<UserIdentity>,


### PR DESCRIPTION
propagation

- Add tower-http trace and request-id features to api/Cargo.toml
- Wire SetRequestIdLayer, PropagateRequestIdLayer, and TraceLayer in app.rs
  - Each request gets a UUID x-request-id (generated if not provided by upstream)
  - http_request span carries request_id, method, uri
  - Response logs status and latency at info level
  - Failures log error and latency at error level
- Add #[tracing::instrument] to all handlers in servers, channels, role, server_members, server_invitations, and friend modules
  - skip(state) on every handler to avoid logging service internals
  - fields(user_id = ...) on every authenticated handler for Loki correlation

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced request tracing infrastructure with automatic request ID generation and propagation across the API.
  * Added structured logging to handler functions to record user context and request metadata.
  * Improved observability by capturing request method, URI, response status, and latency in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->